### PR TITLE
command line options are ignored if there's no config in tauri.conf.json

### DIFF
--- a/src/bin/cargo-tauri-typegen.rs
+++ b/src/bin/cargo-tauri-typegen.rs
@@ -93,11 +93,12 @@ fn run_generate(
         for path in possible_paths {
             if path.exists() {
                 match GenerateConfig::from_tauri_config(&path) {
-                    Ok(loaded_config) => {
+                    Ok(Some(loaded_config)) => {
                         config = loaded_config;
                         config_loaded = true;
                         break;
                     }
+                    Ok(None) => break,
                     Err(_) => continue,
                 }
             }

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -86,11 +86,12 @@ impl BuildSystem {
         if let Some(tauri_config_path) = &project_info.tauri_config_path {
             if tauri_config_path.exists() {
                 match GenerateConfig::from_tauri_config(tauri_config_path) {
-                    Ok(config) => {
+                    Ok(Some(config)) => {
                         self.logger
                             .debug("Loaded configuration from tauri.conf.json");
                         return Ok(config);
                     }
+                    Ok(None) => {}
                     Err(e) => {
                         self.logger.warning(&format!(
                             "Failed to load config from tauri.conf.json: {}. Using defaults.",


### PR DESCRIPTION
Hi,

if there's no configuration in tauri.conf.json file, command line options are ignored, for example

```shell
cargo tauri-typegen generate -v none
```

validation will be ignored
