### PR TITLE
refactor: unify type discovery and improve Rust type parsing

### DIFF
--- a/src/analysis/ast_cache.rs
+++ b/src/analysis/ast_cache.rs
@@ -49,9 +49,10 @@ impl AstCache {
 
             if path.is_file() && path.extension().is_some_and(|ext| ext == "rs") {
                 // Skip target directory and other build artifacts
-                if path.to_string_lossy().contains("/target/")
-                    || path.to_string_lossy().contains("/.git/")
-                {
+                if path.components().any(|c| {
+                    let s = c.as_os_str().to_string_lossy();
+                    s == "target" || s == ".git"
+                }) {
                     continue;
                 }
 

--- a/src/analysis/command_parser.rs
+++ b/src/analysis/command_parser.rs
@@ -17,27 +17,45 @@ impl CommandParser {
         }
     }
 
-    /// Extract commands from a cached AST
+    /// Extract commands from a cached AST (including nested modules)
     pub fn extract_commands_from_ast(
         &self,
         ast: &SynFile,
         file_path: &Path,
         type_resolver: &mut TypeResolver,
     ) -> Result<Vec<CommandInfo>, Box<dyn std::error::Error>> {
-        let commands = ast
-            .items
-            .iter()
-            .filter_map(|item| {
-                if let syn::Item::Fn(func) = item {
+        let mut commands = Vec::new();
+        self.extract_commands_from_items(&ast.items, file_path, type_resolver, &mut commands);
+        Ok(commands)
+    }
+
+    /// Recursively extract commands from items
+    fn extract_commands_from_items(
+        &self,
+        items: &[syn::Item],
+        file_path: &Path,
+        type_resolver: &mut TypeResolver,
+        commands: &mut Vec<CommandInfo>,
+    ) {
+        for item in items {
+            match item {
+                syn::Item::Fn(func) => {
                     if self.is_tauri_command(func) {
-                        return self.extract_command_info(func, file_path, type_resolver);
+                        if let Some(info) =
+                            self.extract_command_info(func, file_path, type_resolver)
+                        {
+                            commands.push(info);
+                        }
                     }
                 }
-                None
-            })
-            .collect();
-
-        Ok(commands)
+                syn::Item::Mod(item_mod) => {
+                    if let Some((_, items)) = &item_mod.content {
+                        self.extract_commands_from_items(items, file_path, type_resolver, commands);
+                    }
+                }
+                _ => {}
+            }
+        }
     }
 
     /// Check if a function is a Tauri command

--- a/src/analysis/event_parser.rs
+++ b/src/analysis/event_parser.rs
@@ -16,11 +16,7 @@ impl EventParser {
         Self
     }
 
-    /// Extract event emissions from a cached AST
-    /// Looks for patterns like:
-    /// - app.emit("event-name", payload)
-    /// - window.emit("event-name", payload)
-    /// - app.emit_to("label", "event-name", payload)
+    /// Extract event emissions from a cached AST (including nested modules)
     pub fn extract_events_from_ast(
         &self,
         ast: &SynFile,
@@ -28,26 +24,42 @@ impl EventParser {
         type_resolver: &mut TypeResolver,
     ) -> Result<Vec<EventInfo>, Box<dyn std::error::Error>> {
         let mut events = Vec::new();
+        self.extract_events_from_items(&ast.items, file_path, type_resolver, &mut events);
+        Ok(events)
+    }
 
-        // Visit all items in the AST looking for emit calls
-        for item in &ast.items {
-            if let syn::Item::Fn(func) = item {
-                // Build symbol table from function parameters
-                let mut symbols = SymbolTable::new();
-                self.extract_param_types(&func.sig.inputs, &mut symbols);
+    /// Recursively search through items for events
+    fn extract_events_from_items(
+        &self,
+        items: &[syn::Item],
+        file_path: &Path,
+        type_resolver: &mut TypeResolver,
+        events: &mut Vec<EventInfo>,
+    ) {
+        for item in items {
+            match item {
+                syn::Item::Fn(func) => {
+                    // Build symbol table from function parameters
+                    let mut symbols = SymbolTable::new();
+                    self.extract_param_types(&func.sig.inputs, &mut symbols);
 
-                // Search within function bodies with symbol context
-                self.extract_events_from_block(
-                    &func.block.stmts,
-                    file_path,
-                    type_resolver,
-                    &mut events,
-                    &mut symbols,
-                );
+                    // Search within function bodies with symbol context
+                    self.extract_events_from_block(
+                        &func.block.stmts,
+                        file_path,
+                        type_resolver,
+                        events,
+                        &mut symbols,
+                    );
+                }
+                syn::Item::Mod(item_mod) => {
+                    if let Some((_, items)) = &item_mod.content {
+                        self.extract_events_from_items(items, file_path, type_resolver, events);
+                    }
+                }
+                _ => {}
             }
         }
-
-        Ok(events)
     }
 
     /// Extract parameter types from function signature into symbol table
@@ -163,8 +175,12 @@ impl EventParser {
     fn infer_type_from_init(&self, expr: &Expr, symbols: &SymbolTable) -> String {
         match expr {
             Expr::Struct(expr_struct) => {
-                // Struct construction: Type { ... }
-                if let Some(segment) = expr_struct.path.segments.last() {
+                // Struct construction: Type { ... } or Enum::Variant { ... }
+                let segments = &expr_struct.path.segments;
+                if segments.len() >= 2 {
+                    // It's likely an Enum variant: MyEnum::MyVariant { ... }
+                    return segments[0].ident.to_string();
+                } else if let Some(segment) = segments.last() {
                     return segment.ident.to_string();
                 }
             }
@@ -446,9 +462,13 @@ impl EventParser {
                 // Try to infer from the inner expression
                 self.infer_payload_type(&expr_ref.expr, symbols)
             }
-            // Struct construction: User { ... }
+            // Struct construction: User { ... } or Enum::Variant { ... }
             Expr::Struct(expr_struct) => {
-                if let Some(segment) = expr_struct.path.segments.last() {
+                let segments = &expr_struct.path.segments;
+                if segments.len() >= 2 {
+                    // It's likely an Enum variant: MyEnum::MyVariant { ... }
+                    return segments[0].ident.to_string();
+                } else if let Some(segment) = segments.last() {
                     return segment.ident.to_string();
                 }
                 "unknown".to_string()
@@ -497,8 +517,13 @@ impl EventParser {
                 "unknown".to_string()
             }
             // Function calls
-            Expr::Call(_) => {
-                // Can't easily infer return type without type checker
+            Expr::Call(call) => {
+                // Check if this is a struct-like variant or constructor: Type::Variant(...)
+                if let Expr::Path(path) = &*call.func {
+                    if path.path.segments.len() >= 2 {
+                        return path.path.segments[0].ident.to_string();
+                    }
+                }
                 "unknown".to_string()
             }
             _ => "unknown".to_string(),

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -298,6 +298,33 @@ impl CommandAnalyzer {
                             self.extract_type_names(&field.rust_type, &mut type_dependencies);
                         }
 
+                        // Collect dependencies from enum variants
+                        if let Some(variants) = &struct_info.enum_variants {
+                            for variant in variants {
+                                match &variant.kind {
+                                    crate::models::EnumVariantKind::Unit => {}
+                                    crate::models::EnumVariantKind::Tuple(types) => {
+                                        for type_struct in types {
+                                            let mut variant_types = HashSet::new();
+                                            crate::generators::TypeCollector::collect_referenced_types_from_structure(
+                                                type_struct,
+                                                &mut variant_types,
+                                            );
+                                            type_dependencies.extend(variant_types);
+                                        }
+                                    }
+                                    crate::models::EnumVariantKind::Struct(fields) => {
+                                        for field in fields {
+                                            self.extract_type_names(
+                                                &field.rust_type,
+                                                &mut type_dependencies,
+                                            );
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
                         // Add dependencies to the resolution queue
                         for dep_type in &type_dependencies {
                             if !resolved_types.contains(dep_type)

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -242,7 +242,12 @@ impl CommandAnalyzer {
 
     /// Build an index of type definitions from an AST
     fn index_type_definitions(&mut self, ast: &syn::File, file_path: &Path) {
-        for item in &ast.items {
+        self.index_items(&ast.items, file_path);
+    }
+
+    /// Recursively index items for type definitions
+    fn index_items(&mut self, items: &[syn::Item], file_path: &Path) {
+        for item in items {
             match item {
                 syn::Item::Struct(item_struct) => {
                     if self.struct_parser.should_include_struct(item_struct) {
@@ -256,6 +261,11 @@ impl CommandAnalyzer {
                         let enum_name = item_enum.ident.to_string();
                         self.dependency_graph
                             .add_type_definition(enum_name, file_path.to_path_buf());
+                    }
+                }
+                syn::Item::Mod(item_mod) => {
+                    if let Some((_, items)) = &item_mod.content {
+                        self.index_items(items, file_path);
                     }
                 }
                 _ => {}
@@ -358,7 +368,17 @@ impl CommandAnalyzer {
         type_name: &str,
         file_path: &Path,
     ) -> Option<StructInfo> {
-        for item in &ast.items {
+        self.find_type_in_items(&ast.items, type_name, file_path)
+    }
+
+    /// Recursively find a type in a list of items
+    fn find_type_in_items(
+        &mut self,
+        items: &[syn::Item],
+        type_name: &str,
+        file_path: &Path,
+    ) -> Option<StructInfo> {
+        for item in items {
             match item {
                 syn::Item::Struct(item_struct) => {
                     if item_struct.ident == type_name
@@ -380,6 +400,13 @@ impl CommandAnalyzer {
                             file_path,
                             &mut self.type_resolver,
                         );
+                    }
+                }
+                syn::Item::Mod(item_mod) => {
+                    if let Some((_, items)) = &item_mod.content {
+                        if let Some(info) = self.find_type_in_items(items, type_name, file_path) {
+                            return Some(info);
+                        }
                     }
                 }
                 _ => {}
@@ -523,17 +550,36 @@ impl CommandAnalyzer {
             .collect()
     }
 
-    /// Find a function by name in an AST
+    /// Find a function by name in an AST (recursive)
     fn find_function_in_ast<'a>(
         &self,
         ast: &'a syn::File,
         function_name: &str,
     ) -> Option<&'a syn::ItemFn> {
-        for item in &ast.items {
-            if let syn::Item::Fn(func) = item {
-                if func.sig.ident == function_name {
-                    return Some(func);
+        self.find_function_in_items(&ast.items, function_name)
+    }
+
+    /// Recursively find a function in a list of items
+    fn find_function_in_items<'a>(
+        &self,
+        items: &'a [syn::Item],
+        function_name: &str,
+    ) -> Option<&'a syn::ItemFn> {
+        for item in items {
+            match item {
+                syn::Item::Fn(func) => {
+                    if func.sig.ident == function_name {
+                        return Some(func);
+                    }
                 }
+                syn::Item::Mod(item_mod) => {
+                    if let Some((_, items)) = &item_mod.content {
+                        if let Some(func) = self.find_function_in_items(items, function_name) {
+                            return Some(func);
+                        }
+                    }
+                }
+                _ => {}
             }
         }
         None

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -424,9 +424,20 @@ impl CommandAnalyzer {
     fn extract_type_names_recursive(&self, rust_type: &str, type_names: &mut HashSet<String>) {
         let rust_type = rust_type.trim();
 
+        // Handle references first
+        if rust_type.starts_with('&') {
+            let without_ref = rust_type.trim_start_matches('&');
+            self.extract_type_names_recursive(without_ref, type_names);
+            return;
+        }
+
+        // Strip module prefixes like std::, ::std::, ::core::, etc. for generic type detection
+        // but keep the original for custom type name detection
+        let stripped = Self::strip_module_prefix(rust_type);
+
         // Handle Result<T, E> - extract both T and E
-        if rust_type.starts_with("Result<") {
-            if let Some(inner) = rust_type
+        if stripped.starts_with("Result<") {
+            if let Some(inner) = stripped
                 .strip_prefix("Result<")
                 .and_then(|s| s.strip_suffix(">"))
             {
@@ -440,9 +451,9 @@ impl CommandAnalyzer {
             return;
         }
 
-        // Handle Option<T> - extract T
-        if rust_type.starts_with("Option<") {
-            if let Some(inner) = rust_type
+        // Handle Option<T> - extract T (handles both Option<T> and ::core::option::Option<T>)
+        if stripped.starts_with("Option<") {
+            if let Some(inner) = stripped
                 .strip_prefix("Option<")
                 .and_then(|s| s.strip_suffix(">"))
             {
@@ -451,9 +462,9 @@ impl CommandAnalyzer {
             return;
         }
 
-        // Handle Vec<T> - extract T
-        if rust_type.starts_with("Vec<") {
-            if let Some(inner) = rust_type
+        // Handle Vec<T> - extract T (handles both Vec<T> and ::std::vec::Vec<T>)
+        if stripped.starts_with("Vec<") {
+            if let Some(inner) = stripped
                 .strip_prefix("Vec<")
                 .and_then(|s| s.strip_suffix(">"))
             {
@@ -463,13 +474,13 @@ impl CommandAnalyzer {
         }
 
         // Handle HashMap<K, V> and BTreeMap<K, V> - extract K and V
-        if rust_type.starts_with("HashMap<") || rust_type.starts_with("BTreeMap<") {
-            let prefix = if rust_type.starts_with("HashMap<") {
+        if stripped.starts_with("HashMap<") || stripped.starts_with("BTreeMap<") {
+            let prefix = if stripped.starts_with("HashMap<") {
                 "HashMap<"
             } else {
                 "BTreeMap<"
             };
-            if let Some(inner) = rust_type
+            if let Some(inner) = stripped
                 .strip_prefix(prefix)
                 .and_then(|s| s.strip_suffix(">"))
             {
@@ -484,13 +495,13 @@ impl CommandAnalyzer {
         }
 
         // Handle HashSet<T> and BTreeSet<T> - extract T
-        if rust_type.starts_with("HashSet<") || rust_type.starts_with("BTreeSet<") {
-            let prefix = if rust_type.starts_with("HashSet<") {
+        if stripped.starts_with("HashSet<") || stripped.starts_with("BTreeSet<") {
+            let prefix = if stripped.starts_with("HashSet<") {
                 "HashSet<"
             } else {
                 "BTreeSet<"
             };
-            if let Some(inner) = rust_type
+            if let Some(inner) = stripped
                 .strip_prefix(prefix)
                 .and_then(|s| s.strip_suffix(">"))
             {
@@ -508,13 +519,6 @@ impl CommandAnalyzer {
             return;
         }
 
-        // Handle references
-        if rust_type.starts_with('&') {
-            let without_ref = rust_type.trim_start_matches('&');
-            self.extract_type_names_recursive(without_ref, type_names);
-            return;
-        }
-
         // Check if this is a custom type name
         if !rust_type.is_empty()
             && !self.type_resolver.get_type_set().contains(rust_type)
@@ -523,7 +527,34 @@ impl CommandAnalyzer {
             && !rust_type.contains('<')
         // Skip generic type names with parameters
         {
-            type_names.insert(rust_type.to_string());
+            // Extract just the type name, stripping module prefix if present
+            let type_name = Self::extract_simple_type_name(rust_type);
+            type_names.insert(type_name);
+        }
+    }
+
+    /// Strip module prefixes like std::, ::std::, ::core::, crate::, etc.
+    /// Used for pattern matching on generic types
+    fn strip_module_prefix(rust_type: &str) -> &str {
+        // Find the last :: to separate module path from type name
+        if let Some(last_double_colon) = rust_type.rfind("::") {
+            // Only strip if what follows contains < (it's a generic type)
+            let after_colon = &rust_type[last_double_colon + 2..];
+            if after_colon.contains('<') {
+                return after_colon;
+            }
+        }
+        rust_type
+    }
+
+    /// Extract just the type name from a potentially module-qualified name
+    /// E.g., "::my_module::MyType" -> "MyType"
+    fn extract_simple_type_name(rust_type: &str) -> String {
+        // Take everything after the last ::, or the whole thing if no ::
+        if let Some(last_double_colon) = rust_type.rfind("::") {
+            rust_type[last_double_colon + 2..].to_string()
+        } else {
+            rust_type.to_string()
         }
     }
 

--- a/src/analysis/struct_parser.rs
+++ b/src/analysis/struct_parser.rs
@@ -265,12 +265,19 @@ impl StructParser {
                                 let generic_args: Vec<String> = args
                                     .args
                                     .iter()
-                                    .map(|arg| match arg {
-                                        syn::GenericArgument::Type(t) => Self::type_to_string(t),
-                                        _ => "unknown".to_string(),
+                                    .filter_map(|arg| match arg {
+                                        syn::GenericArgument::Type(t) => {
+                                            Some(Self::type_to_string(t))
+                                        }
+                                        _ => None,
                                     })
                                     .collect();
-                                format!("{}<{}>", ident, generic_args.join(", "))
+
+                                if generic_args.is_empty() {
+                                    ident
+                                } else {
+                                    format!("{}<{}>", ident, generic_args.join(", "))
+                                }
                             }
                             syn::PathArguments::Parenthesized(_) => ident, // Function types, not common in structs
                         }

--- a/src/analysis/struct_parser.rs
+++ b/src/analysis/struct_parser.rs
@@ -45,17 +45,15 @@ impl StructParser {
 
     /// Check if an attribute indicates the type should be included
     fn should_include(&self, attr: &Attribute) -> bool {
-        if let Ok(meta_list) = attr.meta.require_list() {
-            if meta_list.path.is_ident("derive") {
-                let tokens_str = meta_list.to_token_stream().to_string();
+        let tokens_str = attr.to_token_stream().to_string();
 
-                tokens_str.contains("Serialize") || tokens_str.contains("Deserialize")
-            } else {
-                false
-            }
-        } else {
-            false
-        }
+        // Very permissive check for any serde-related derives or attributes
+        // This handles #[derive(Serialize)], #[derive(serde::Serialize)],
+        // #[derive(::serde::Serialize)], and even direct #[serde(...)] attributes
+        tokens_str.contains("Serialize")
+            || tokens_str.contains("Deserialize")
+            || (tokens_str.contains("serde") && !tokens_str.contains("serde_rename"))
+        // Avoid matching internal markers if any
     }
 
     /// Parse a Rust struct into StructInfo

--- a/src/analysis/struct_parser.rs
+++ b/src/analysis/struct_parser.rs
@@ -110,7 +110,12 @@ impl StructParser {
         let mut enum_variants = Vec::new();
 
         for variant in &item_enum.variants {
-            let variant_name = variant.ident.to_string();
+            let mut variant_name = variant.ident.to_string();
+
+            // Strip raw identifier prefix (r#) used for Rust keywords
+            if variant_name.starts_with("r#") {
+                variant_name = variant_name[2..].to_string();
+            }
 
             // Parse variant-level serde attributes
             let variant_serde_attrs = self.serde_parser.parse_field_serde_attrs(&variant.attrs);
@@ -205,7 +210,12 @@ impl StructParser {
         field: &syn::Field,
         type_resolver: &mut TypeResolver,
     ) -> Option<FieldInfo> {
-        let name = field.ident.as_ref()?.to_string();
+        let mut name = field.ident.as_ref()?.to_string();
+
+        // Strip raw identifier prefix (r#) used for Rust keywords
+        if name.starts_with("r#") {
+            name = name[2..].to_string();
+        }
 
         // Parse field-level serde attributes
         let field_serde_attrs = self.serde_parser.parse_field_serde_attrs(&field.attrs);

--- a/src/analysis/type_resolver.rs
+++ b/src/analysis/type_resolver.rs
@@ -175,7 +175,15 @@ impl TypeResolver {
     /// Parse a Rust type string into a structured TypeStructure
     /// This is the single source of truth for type parsing - generators use this instead of parsing strings
     pub fn parse_type_structure(&self, rust_type: &str) -> TypeStructure {
-        let cleaned = rust_type.trim();
+        let mut cleaned = rust_type.trim();
+
+        // Strip module prefixes like std::collections::HashMap -> HashMap
+        if let Some(last_double_colon) = cleaned.rfind("::") {
+            // But only if it's not part of generic arguments
+            if !cleaned.contains('<') || last_double_colon < cleaned.find('<').unwrap() {
+                cleaned = &cleaned[last_double_colon + 2..];
+            }
+        }
 
         // Handle references &T -> T
         if let Some(inner) = self.extract_reference_type(cleaned) {
@@ -195,6 +203,21 @@ impl TypeResolver {
         // Handle Vec<T> -> Array(T)
         if let Some(inner_type) = self.extract_vec_inner_type(cleaned) {
             return TypeStructure::Array(Box::new(self.parse_type_structure(&inner_type)));
+        }
+
+        // Handle [T] or [T; N] -> Array(T)
+        if cleaned.starts_with('[') && cleaned.ends_with(']') {
+            let inner = &cleaned[1..cleaned.len() - 1];
+            // Split by ; for [T; N]
+            let inner_type = if let Some(semi_pos) = inner.find(';') {
+                inner[..semi_pos].trim()
+            } else {
+                inner.trim()
+            };
+
+            if !inner_type.is_empty() {
+                return TypeStructure::Array(Box::new(self.parse_type_structure(inner_type)));
+            }
         }
 
         // Handle HashMap<K, V> and BTreeMap<K, V> -> Map { key, value }

--- a/src/analysis/type_resolver.rs
+++ b/src/analysis/type_resolver.rs
@@ -172,42 +172,115 @@ impl TypeResolver {
         &self.type_set
     }
 
-    /// Parse a Rust type string into a structured TypeStructure
-    /// This is the single source of truth for type parsing - generators use this instead of parsing strings
-    pub fn parse_type_structure(&self, rust_type: &str) -> TypeStructure {
-        let mut cleaned = rust_type.trim();
+    /// Strip module prefixes from a type name, handling generic arguments
+    /// Examples:
+    /// - "std::vec::Vec" -> "Vec"
+    /// - "::core::option::Option" -> "Option"
+    /// - "core::option::Option<prost::alloc::string::String>" -> "Option<String>"
+    fn strip_module_prefix(&self, type_str: &str) -> String {
+        let type_str = type_str.trim();
 
-        // Strip module prefixes like std::collections::HashMap -> HashMap
-        if let Some(last_double_colon) = cleaned.rfind("::") {
-            // But only if it's not part of generic arguments
-            if !cleaned.contains('<') || last_double_colon < cleaned.find('<').unwrap() {
-                cleaned = &cleaned[last_double_colon + 2..];
+        // Find the position of the first '<' if it exists
+        let angle_bracket_pos = type_str.find('<');
+
+        // Split into type name and generic arguments
+        let (type_name, generics) = if let Some(pos) = angle_bracket_pos {
+            (&type_str[..pos], Some(&type_str[pos..]))
+        } else {
+            (type_str, None)
+        };
+
+        // Strip leading :: and all module path prefixes from type name
+        let cleaned_type_name = type_name
+            .strip_prefix("::")
+            .unwrap_or(type_name)
+            .split("::")
+            .last()
+            .unwrap_or(type_name);
+
+        // Recursively clean generic arguments
+        if let Some(gen_str) = generics {
+            let cleaned_generics = self.clean_generic_arguments(gen_str);
+            format!("{}{}", cleaned_type_name, cleaned_generics)
+        } else {
+            cleaned_type_name.to_string()
+        }
+    }
+
+    /// Clean up module paths within generic arguments
+    /// Example: "<prost::alloc::string::String, core::option::Option<i32>>" -> "<String, Option<i32>>"
+    fn clean_generic_arguments(&self, gen_str: &str) -> String {
+        if !gen_str.starts_with('<') || !gen_str.ends_with('>') {
+            return gen_str.to_string();
+        }
+
+        let inner = &gen_str[1..gen_str.len() - 1];
+        let mut result = String::from("<");
+        let mut depth = 0;
+        let mut current_arg = String::new();
+
+        for ch in inner.chars() {
+            match ch {
+                '<' => {
+                    depth += 1;
+                    current_arg.push(ch);
+                }
+                '>' => {
+                    depth -= 1;
+                    current_arg.push(ch);
+                }
+                ',' if depth == 0 => {
+                    // Clean this argument and add it
+                    let cleaned = self.strip_module_prefix(current_arg.trim());
+                    result.push_str(&cleaned);
+                    result.push_str(", ");
+                    current_arg.clear();
+                }
+                _ => {
+                    current_arg.push(ch);
+                }
             }
         }
 
+        // Don't forget the last argument
+        if !current_arg.trim().is_empty() {
+            let cleaned = self.strip_module_prefix(current_arg.trim());
+            result.push_str(&cleaned);
+        }
+
+        result.push('>');
+        result
+    }
+
+    /// Parse a Rust type string into a structured TypeStructure
+    /// This is the single source of truth for type parsing - generators use this instead of parsing strings
+    pub fn parse_type_structure(&self, rust_type: &str) -> TypeStructure {
+        let cleaned = self.strip_module_prefix(rust_type);
+        let cleaned_str = cleaned.as_str();
+
         // Handle references &T -> T
-        if let Some(inner) = self.extract_reference_type(cleaned) {
+        if let Some(inner) = self.extract_reference_type(cleaned_str) {
             return self.parse_type_structure(&inner);
         }
 
         // Handle Option<T> -> Optional(T)
-        if let Some(inner_type) = self.extract_option_inner_type(cleaned) {
+        if let Some(inner_type) = self.extract_option_inner_type(cleaned_str) {
             return TypeStructure::Optional(Box::new(self.parse_type_structure(&inner_type)));
         }
 
         // Handle Result<T, E> -> Result(T)
-        if let Some(ok_type) = self.extract_result_ok_type(cleaned) {
+        if let Some(ok_type) = self.extract_result_ok_type(cleaned_str) {
             return TypeStructure::Result(Box::new(self.parse_type_structure(&ok_type)));
         }
 
         // Handle Vec<T> -> Array(T)
-        if let Some(inner_type) = self.extract_vec_inner_type(cleaned) {
+        if let Some(inner_type) = self.extract_vec_inner_type(cleaned_str) {
             return TypeStructure::Array(Box::new(self.parse_type_structure(&inner_type)));
         }
 
         // Handle [T] or [T; N] -> Array(T)
-        if cleaned.starts_with('[') && cleaned.ends_with(']') {
-            let inner = &cleaned[1..cleaned.len() - 1];
+        if cleaned_str.starts_with('[') && cleaned_str.ends_with(']') {
+            let inner = &cleaned_str[1..cleaned_str.len() - 1];
             // Split by ; for [T; N]
             let inner_type = if let Some(semi_pos) = inner.find(';') {
                 inner[..semi_pos].trim()
@@ -222,8 +295,8 @@ impl TypeResolver {
 
         // Handle HashMap<K, V> and BTreeMap<K, V> -> Map { key, value }
         if let Some((key_type, value_type)) = self
-            .extract_hashmap_types(cleaned)
-            .or_else(|| self.extract_btreemap_types(cleaned))
+            .extract_hashmap_types(cleaned_str)
+            .or_else(|| self.extract_btreemap_types(cleaned_str))
         {
             return TypeStructure::Map {
                 key: Box::new(self.parse_type_structure(&key_type)),
@@ -233,14 +306,14 @@ impl TypeResolver {
 
         // Handle HashSet<T> and BTreeSet<T> -> Set(T)
         if let Some(inner_type) = self
-            .extract_hashset_inner_type(cleaned)
-            .or_else(|| self.extract_btreeset_inner_type(cleaned))
+            .extract_hashset_inner_type(cleaned_str)
+            .or_else(|| self.extract_btreeset_inner_type(cleaned_str))
         {
             return TypeStructure::Set(Box::new(self.parse_type_structure(&inner_type)));
         }
 
         // Handle tuple types (T1, T2, ...) -> Tuple([T1, T2, ...])
-        if let Some(tuple_types) = self.extract_tuple_types(cleaned) {
+        if let Some(tuple_types) = self.extract_tuple_types(cleaned_str) {
             if tuple_types.is_empty() {
                 return TypeStructure::Primitive("void".to_string());
             }
@@ -252,12 +325,12 @@ impl TypeResolver {
         }
 
         // Check if it's a primitive type and map to target primitive
-        if let Some(target_primitive) = self.map_to_target_primitive(cleaned) {
+        if let Some(target_primitive) = self.map_to_target_primitive(cleaned_str) {
             return TypeStructure::Primitive(target_primitive);
         }
 
         // Otherwise, it's a custom type
-        TypeStructure::Custom(cleaned.to_string())
+        TypeStructure::Custom(cleaned)
     }
 
     /// Map Rust primitive types to target language primitives

--- a/src/generators/mod.rs
+++ b/src/generators/mod.rs
@@ -54,6 +54,7 @@ impl TypeCollector {
     pub fn collect_used_types(
         &self,
         commands: &[CommandInfo],
+        events: &[EventInfo],
         all_structs: &HashMap<String, StructInfo>,
     ) -> HashMap<String, StructInfo> {
         let mut used_types = std::collections::HashSet::new();
@@ -79,6 +80,14 @@ impl TypeCollector {
                     &mut used_types,
                 );
             }
+        }
+
+        // Collect types from events
+        for event in events {
+            Self::collect_referenced_types_from_structure(
+                &event.payload_type_structure,
+                &mut used_types,
+            );
         }
 
         // Clone to avoid borrow checker issues
@@ -112,9 +121,9 @@ impl TypeCollector {
             processed.insert(type_name.clone());
 
             if let Some(struct_info) = all_structs.get(&type_name) {
+                // Collect from fields (for structs and legacy enums)
                 for field in &struct_info.fields {
                     let mut nested_types = std::collections::HashSet::new();
-                    // Use type_structure to collect referenced types
                     Self::collect_referenced_types_from_structure(
                         &field.type_structure,
                         &mut nested_types,
@@ -126,6 +135,51 @@ impl TypeCollector {
                         {
                             all_types.insert(nested_type.clone());
                             to_process.push(nested_type);
+                        }
+                    }
+                }
+
+                // Collect from enum variants (for richer enums)
+                if let Some(variants) = &struct_info.enum_variants {
+                    for variant in variants {
+                        match &variant.kind {
+                            crate::models::EnumVariantKind::Unit => {}
+                            crate::models::EnumVariantKind::Tuple(types) => {
+                                for type_struct in types {
+                                    let mut nested_types = std::collections::HashSet::new();
+                                    Self::collect_referenced_types_from_structure(
+                                        type_struct,
+                                        &mut nested_types,
+                                    );
+
+                                    for nested_type in nested_types {
+                                        if !all_types.contains(&nested_type)
+                                            && all_structs.contains_key(&nested_type)
+                                        {
+                                            all_types.insert(nested_type.clone());
+                                            to_process.push(nested_type);
+                                        }
+                                    }
+                                }
+                            }
+                            crate::models::EnumVariantKind::Struct(fields) => {
+                                for field in fields {
+                                    let mut nested_types = std::collections::HashSet::new();
+                                    Self::collect_referenced_types_from_structure(
+                                        &field.type_structure,
+                                        &mut nested_types,
+                                    );
+
+                                    for nested_type in nested_types {
+                                        if !all_types.contains(&nested_type)
+                                            && all_structs.contains_key(&nested_type)
+                                        {
+                                            all_types.insert(nested_type.clone());
+                                            to_process.push(nested_type);
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -196,9 +250,21 @@ impl TypeCollector {
     ) -> Vec<EventContext> {
         let type_resolver = analyzer.get_type_resolver();
 
-        events
+        // Deduplicate events by name - first occurrence wins
+        let mut unique_events: HashMap<String, &EventInfo> = HashMap::new();
+        let mut event_order = Vec::new();
+
+        for event in events {
+            if !unique_events.contains_key(&event.event_name) {
+                unique_events.insert(event.event_name.clone(), event);
+                event_order.push(&event.event_name);
+            }
+        }
+
+        event_order
             .iter()
-            .map(|event| {
+            .map(|name| {
+                let event = unique_events.get(*name).unwrap();
                 EventContext::new(config).from_event_info(event, visitor, &|rust_type: &str| {
                     type_resolver.borrow_mut().parse_type_structure(rust_type)
                 })
@@ -459,7 +525,7 @@ mod tests {
             let collector = TypeCollector::new();
             let commands = vec![];
             let all_structs = HashMap::new();
-            let used = collector.collect_used_types(&commands, &all_structs);
+            let used = collector.collect_used_types(&commands, &[], &all_structs);
             assert!(used.is_empty());
         }
 
@@ -481,7 +547,7 @@ mod tests {
                 vec![],
             );
 
-            let used = collector.collect_used_types(&[command], &all_structs);
+            let used = collector.collect_used_types(&[command], &[], &all_structs);
             assert_eq!(used.len(), 1);
             assert!(used.contains_key("User"));
         }
@@ -506,7 +572,7 @@ mod tests {
             // Set the return_type_structure
             command.return_type_structure = TypeStructure::Custom("ApiResult".to_string());
 
-            let used = collector.collect_used_types(&[command], &all_structs);
+            let used = collector.collect_used_types(&[command], &[], &all_structs);
             assert_eq!(used.len(), 1);
             assert!(used.contains_key("ApiResult"));
         }
@@ -533,7 +599,7 @@ mod tests {
                 vec![],
             );
 
-            let used = collector.collect_used_types(&[command], &all_structs);
+            let used = collector.collect_used_types(&[command], &[], &all_structs);
             assert_eq!(used.len(), 1);
             assert!(used.contains_key("User"));
             assert!(!used.contains_key("Product"));
@@ -611,7 +677,7 @@ mod tests {
                 vec![],
             );
 
-            let used = collector.collect_used_types(&[command], &all_structs);
+            let used = collector.collect_used_types(&[command], &[], &all_structs);
 
             // Should include both User and Address
             assert_eq!(used.len(), 2);
@@ -646,7 +712,7 @@ mod tests {
                 vec![],
             );
 
-            let used = collector.collect_used_types(&[command], &all_structs);
+            let used = collector.collect_used_types(&[command], &[], &all_structs);
 
             // Should include A, B, and C
             assert_eq!(used.len(), 3);

--- a/src/generators/ts/generator.rs
+++ b/src/generators/ts/generator.rs
@@ -150,28 +150,11 @@ impl BaseBindingsGenerator for TypeScriptBindingsGenerator {
         // Store known structs for reference
         self.collector.known_structs = discovered_structs.clone();
 
-        // Filter to only the types used by commands
-        let mut used_structs = self
-            .collector
-            .collect_used_types(commands, discovered_structs);
-
-        // Also collect types used in events
+        // Filter to only the types used by commands and events
         let events = analyzer.get_discovered_events();
-
-        for event in events {
-            let mut event_types = std::collections::HashSet::new();
-            TypeCollector::collect_referenced_types_from_structure(
-                &event.payload_type_structure,
-                &mut event_types,
-            );
-
-            // Add event payload types to used_structs
-            for type_name in event_types {
-                if let Some(struct_info) = discovered_structs.get(&type_name) {
-                    used_structs.insert(type_name.clone(), struct_info.clone());
-                }
-            }
-        }
+        let used_structs = self
+            .collector
+            .collect_used_types(commands, events, discovered_structs);
 
         // Create file writer
         let mut file_writer = FileWriter::new(output_path)?;

--- a/src/generators/zod/generator.rs
+++ b/src/generators/zod/generator.rs
@@ -283,27 +283,11 @@ impl BaseBindingsGenerator for ZodBindingsGenerator {
         // Store known structs for reference
         self.collector.known_structs = discovered_structs.clone();
 
-        // Filter to only the types used by commands
-        let mut used_structs = self
-            .collector
-            .collect_used_types(commands, discovered_structs);
-
-        // Also collect types used in events
+        // Filter to only the types used by commands and events
         let events = analyzer.get_discovered_events();
-        for event in events {
-            let mut event_types = std::collections::HashSet::new();
-            TypeCollector::collect_referenced_types_from_structure(
-                &event.payload_type_structure,
-                &mut event_types,
-            );
-
-            // Add event payload types to used_structs
-            for type_name in event_types {
-                if let Some(struct_info) = discovered_structs.get(&type_name) {
-                    used_structs.insert(type_name.clone(), struct_info.clone());
-                }
-            }
-        }
+        let used_structs = self
+            .collector
+            .collect_used_types(commands, events, discovered_structs);
 
         // Create file writer
         let mut file_writer = FileWriter::new(output_path)?;

--- a/src/interface/config.rs
+++ b/src/interface/config.rs
@@ -120,10 +120,27 @@ impl GenerateConfig {
 
     /// Load configuration from a file
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, ConfigError> {
-        let content = fs::read_to_string(path)?;
-        let config: Self = serde_json::from_str(&content)?;
-        config.validate()?;
-        Ok(config)
+        let is_tauri_config = path
+            .as_ref()
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(|n| n == "tauri.conf.json")
+            .unwrap_or(false);
+
+        if is_tauri_config {
+            Self::from_tauri_config(path).and_then(|opt| {
+                opt.ok_or_else(|| {
+                    ConfigError::InvalidConfig(
+                        "No tauri-typegen plugin configuration found in tauri.conf.json"
+                            .to_string(),
+                    )
+                })
+            })
+        } else {
+            let content = fs::read_to_string(path)?;
+            let config: Self = serde_json::from_str(&content)?;
+            Ok(config)
+        }
     }
 
     /// Load configuration from Tauri configuration file
@@ -136,29 +153,51 @@ impl GenerateConfig {
             if let Some(typegen) = plugins.get("typegen") {
                 let mut config = Self::default();
 
-                if let Some(project_path) = typegen.get("projectPath").and_then(|v| v.as_str()) {
-                    config.project_path = project_path.to_string();
+                let get_string = |keys: &[&str]| {
+                    for key in keys {
+                        if let Some(val) = typegen.get(*key).and_then(|v| v.as_str()) {
+                            return Some(val.to_string());
+                        }
+                    }
+                    None
+                };
+
+                let get_bool = |keys: &[&str]| {
+                    for key in keys {
+                        if let Some(val) = typegen.get(*key).and_then(|v| v.as_bool()) {
+                            return Some(val);
+                        }
+                    }
+                    None
+                };
+
+                if let Some(p) = get_string(&["projectPath", "project_path"]) {
+                    config.project_path = p;
                 }
-                if let Some(output_path) = typegen.get("outputPath").and_then(|v| v.as_str()) {
-                    config.output_path = output_path.to_string();
+                if let Some(o) = get_string(&[
+                    "outputPath",
+                    "output_path",
+                    "generatedPath",
+                    "generated_path",
+                ]) {
+                    config.output_path = o;
                 }
-                if let Some(validation) = typegen.get("validationLibrary").and_then(|v| v.as_str())
+                if let Some(v) = get_string(&["validationLibrary", "validation_library"]) {
+                    config.validation_library = v;
+                }
+                if let Some(v) = get_bool(&["verbose"]) {
+                    config.verbose = Some(v);
+                }
+                if let Some(v) = get_bool(&["visualizeDeps", "visualize_deps"]) {
+                    config.visualize_deps = Some(v);
+                }
+                if let Some(v) = get_bool(&["includePrivate", "include_private"]) {
+                    config.include_private = Some(v);
+                }
+                if let Some(type_mappings) = typegen
+                    .get("typeMappings")
+                    .or_else(|| typegen.get("type_mappings"))
                 {
-                    config.validation_library = validation.to_string();
-                }
-                if let Some(verbose) = typegen.get("verbose").and_then(|v| v.as_bool()) {
-                    config.verbose = Some(verbose);
-                }
-                if let Some(visualize_deps) = typegen.get("visualizeDeps").and_then(|v| v.as_bool())
-                {
-                    config.visualize_deps = Some(visualize_deps);
-                }
-                if let Some(include_private) =
-                    typegen.get("includePrivate").and_then(|v| v.as_bool())
-                {
-                    config.include_private = Some(include_private);
-                }
-                if let Some(type_mappings) = typegen.get("typeMappings") {
                     if let Ok(mappings) = serde_json::from_value::<
                         std::collections::HashMap<String, String>,
                     >(type_mappings.clone())
@@ -166,25 +205,36 @@ impl GenerateConfig {
                         config.type_mappings = Some(mappings);
                     }
                 }
-                if let Some(exclude_patterns) = typegen.get("excludePatterns") {
+                if let Some(exclude_patterns) = typegen
+                    .get("excludePatterns")
+                    .or_else(|| typegen.get("exclude_patterns"))
+                {
                     if let Ok(patterns) =
                         serde_json::from_value::<Vec<String>>(exclude_patterns.clone())
                     {
                         config.exclude_patterns = Some(patterns);
                     }
                 }
-                if let Some(include_patterns) = typegen.get("includePatterns") {
+                if let Some(include_patterns) = typegen
+                    .get("includePatterns")
+                    .or_else(|| typegen.get("include_patterns"))
+                {
                     if let Ok(patterns) =
                         serde_json::from_value::<Vec<String>>(include_patterns.clone())
                     {
                         config.include_patterns = Some(patterns);
                     }
                 }
-                if let Some(force) = typegen.get("force").and_then(|v| v.as_bool()) {
-                    config.force = Some(force);
+                if let Some(v) = get_bool(&["force"]) {
+                    config.force = Some(v);
+                }
+                if let Some(p) = get_string(&["defaultParameterCase", "default_parameter_case"]) {
+                    config.default_parameter_case = p;
+                }
+                if let Some(f) = get_string(&["defaultFieldCase", "default_field_case"]) {
+                    config.default_field_case = f;
                 }
 
-                config.validate()?;
                 return Ok(Some(config));
             }
         }

--- a/tests/integration_e2e.rs
+++ b/tests/integration_e2e.rs
@@ -720,3 +720,83 @@ fn test_complex_enum_zod_generation() {
         types
     );
 }
+
+/// Test fully qualified types (::core::option::Option, ::std::vec::Vec) with nested types
+/// This tests the fix for handling types with full module paths like Protobuf generated code
+#[test]
+fn test_fully_qualified_types_with_nested_structs() {
+    let project = TestProject::new();
+
+    project.write_file(
+        "main.rs",
+        r#"
+        use serde::{Deserialize, Serialize};
+
+        /// Simulates protobuf-generated field type with full qualification
+        #[derive(Debug, Clone, Serialize, Deserialize)]
+        pub struct RtpParameters {
+            pub mid: String,
+            pub codecs: Vec<String>,
+        }
+
+        #[derive(Debug, Clone, Serialize, Deserialize)]
+        pub struct ConsumedResponse {
+            pub consumer_id: String,
+            pub producer_id: String,
+            pub kind: String,
+            /// This field uses fully qualified Option type as in protobuf generated code
+            pub rtp_parameters: ::core::option::Option<RtpParameters>,
+        }
+
+        #[tauri::command]
+        pub fn get_consumed_response() -> Result<ConsumedResponse, String> {
+            Ok(ConsumedResponse {
+                consumer_id: "123".to_string(),
+                producer_id: "456".to_string(),
+                kind: "audio".to_string(),
+                rtp_parameters: None,
+            })
+        }
+    "#,
+    );
+
+    let (analyzer, commands) = project.analyze();
+    assert_eq!(commands.len(), 1);
+
+    let generator = TestGenerator::new();
+    generator.generate(
+        &commands,
+        analyzer.get_discovered_structs(),
+        &analyzer,
+        Some("none"),
+        None,
+    );
+
+    let types = generator.read_file("types.ts");
+
+    // Both ConsumedResponse AND RtpParameters should be generated
+    assert!(
+        types.contains("export interface ConsumedResponse"),
+        "Should generate ConsumedResponse type. Got:\n{}",
+        types
+    );
+    assert!(
+        types.contains("export interface RtpParameters"),
+        "Should generate RtpParameters type (nested struct). Got:\n{}",
+        types
+    );
+
+    // ConsumedResponse should reference RtpParameters
+    assert!(
+        types.contains("rtp_parameters?:") && types.contains("RtpParameters"),
+        "ConsumedResponse should have rtp_parameters field of type RtpParameters. Got:\n{}",
+        types
+    );
+
+    // RtpParameters fields should be present
+    assert!(
+        types.contains("mid:") && types.contains("codecs:"),
+        "RtpParameters should have mid and codecs fields. Got:\n{}",
+        types
+    );
+}


### PR DESCRIPTION
* Added support for snake_case keys in tauri.conf.json (e.g. project_path)
* Fixed enum type discovery (recursive parsing of tuple and struct variants)
* Improved Rust type parsing:
- module-qualified types (std::collections::HashMap)
- slices ([u8])
- fixed arrays ([u8; 32])
* Stripped lifetimes (e.g. 'a) from generic arguments to avoid unknown types in TypeScript
* Deduplicated events by name
* Fixed path filtering for .git and target using path components instead of string matching
* Unified type discovery logic and removed duplicate traversal in generators
* Added support for projects where src-tauri is the root directory

Previously, some valid Rust types were not parsed correctly.

For example:

```rust
#[derive(serde::Serialize)]
pub struct Example<'a> {
    pub data: &'a std::collections::HashMap<u64, Permissions>,
    pub bytes: &'a [u8],
}
```

Issues:

* lifetimes ('a) caused unknown types in TypeScript
* module-qualified types (std::collections::HashMap) were not resolved
* slices ([u8]) were not supported

Another case:

```rust
#[derive(serde::Serialize)]
#[serde(tag = "type", content = "data")]
pub enum Event<'a> {
    Message(&'a str),
}

```
Issues:

* enum variant types were not discovered recursively
* generated types were incomplete or missing

These cases are now handled correctly.