### PR TITLE
fix: exclude type-aliased Tauri injectables from generated TypeScript params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
-
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.5.3] - 2026-08-24
+
+### Fixed
+
+- **Aliased Tauri Command Parameters**: Type aliases to Tauri-injected types (e.g. `type AppSaveState<'a> = State<'a, Arc<T>>`) are now resolved and skipped when generating command Params, matching the behavior of a direct `State<...>` / `AppHandle` / etc. parameter
+  - Nested aliases are followed with cycle detection
+  - Analysis indexes type aliases before command extraction so same-file and cross-file aliases work
 
 ## [0.5.2] - 2026-06-21
 
 ### Fixed
+
 - **Duplicate Commands Under `#[cfg(...)]` Gates**: Commands declared more than once behind mutually-exclusive `#[cfg(...)]` attributes (the standard cross-platform Tauri pattern) now generate a single TypeScript declaration instead of duplicates (TS2323/TS2393/TS2451)
   - Commands are deduplicated by name at the generation layer (first occurrence in source order wins), consistent with existing event deduplication
   - The analyzer continues to report every declaration; deduplication happens only when building generation contexts
@@ -16,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.1] - 2026-05-28
 
 ### Fixed
+
 - **Deterministic Generation**: Eliminated nondeterministic output across runs
   - Generator inputs are now sorted before rendering for stable ordering
   - Stabilized cache hashing and regeneration invalidation
@@ -23,13 +32,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Normalized generated output formatting
 
 ### Added
+
 - **Snake_case Config Keys**: Support `snake_case` keys in `tauri.conf.json` (e.g. `project_path`)
 - **`src-tauri` as Root**: Support projects where `src-tauri` is the root directory
 
 ### Changed
+
 - **Unified Type Discovery**: Consolidated type discovery logic and removed duplicate traversal in the generators
 
 ### Fixed
+
 - **Rust Type Parsing**: Correctly parse previously unsupported types
   - Module-qualified types (e.g. `std::collections::HashMap`)
   - Slices (e.g. `[u8]`)
@@ -42,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.0] - 2026-02-24
 
 ### Added
+
 - **Complex Enum Variant Support**: Full support for Rust enums with tuple and struct variants
   - Simple enums (unit variants only) continue to generate TypeScript string literal unions / `z.enum()`
   - Complex enums (tuple or struct variants) now generate TypeScript discriminated unions / `z.discriminatedUnion()`
@@ -49,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Enum variants are included in the AST cache for efficient subsequent runs
 
 ### Changed
+
 - **Serde Attribute Parsing**: Replaced regex-based parsing with `syn` AST functions
   - More robust and accurate handling of `#[serde(...)]` attributes
   - Eliminates edge cases caused by pattern matching on raw token strings
@@ -56,11 +70,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.2] - 2026-02-15
 
 ### Fixed
+
 - **EventParser**: Fixed bug where types were not discovered when moving emitter to external function
 
 ## [0.4.1] - 2026-02-05
 
 ### Added
+
 - **Smart Caching**: Skip regeneration when source files haven't changed
   - Creates `.typecache` file in output directory with hashes of discovered commands, types, and configuration
   - Compares hashes on subsequent runs to determine if regeneration is needed
@@ -74,6 +90,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.0] - 2025-12-26
 
 ### Added
+
 - **Custom Type Mappings**: Added support for mapping external Rust types to TypeScript types via configuration
   - Configure in `tauri.conf.json` under `plugins.typegen.typeMappings`
   - Useful for external crate types like `DateTime<Utc>` → `string` or `PathBuf` → `string`
@@ -96,40 +113,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Ensures generated TypeScript/Zod code has no compilation errors
 
 ### Fixed
-- Updated outdated setup instructions 
+
+- Updated outdated setup instructions
 
 ### Changed
+
 - **BREAKING - TypeScript Type Mappings**: Changed HashMap/BTreeMap generation from `Map<K,V>` to `Record<K,V>`
   - `HashMap<String, number>` now generates `Record<string, number>` instead of `Map<string, number>`
   - More idiomatic TypeScript that matches JSON serialization behavior
 
 ## [0.3.4] - 2025-12-09
+
 ### Fixed
+
 - **Zod**: Fixed bug where `z.coerce.number()` was used for record/map declaration
 
 ## [0.3.3] - 2025-12-04
 
 ### Added
+
 - Generated files now contain a timestamp and tauri-typegen version info
 - Added `--version` flag as CLI argument
 
-
 ### Changed
+
 - Generated zod code now includes type coercion for numbers
 
 ## [0.3.2] - 2025-11-23
 
 ### Fixed
+
 - **Nested Collection Type Discovery**: Fixed bug where nested collection types (e.g., `Vec<HashMap<String, Vec<T>>>`) were not properly discovered when the type was not referenced standalone
   - Type analyzer now recursively traverses nested generic types to discover all referenced custom types
   - Ensures all nested types are included in the generated TypeScript bindings
 
 ### Changed
+
 - Cleaned up unused permissions directory from project structure
 
 ## [0.3.1] - 2025-11-19
 
 ### Fixed
+
 - **Zod Command Generation with Channels**: Fixed bug where commands with both regular parameters and channels generated invalid TypeScript code
   - Previously referenced non-existent `extractChannels` function
   - Now generates explicit channel parameter references (e.g., `{ ...result.data, onProgress: params.onProgress }`)
@@ -137,6 +162,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.0] - 2025-11-13
 
 ### Added
+
 - **Tauri Channel Support**: Automatically generate TypeScript bindings for Tauri IPC Channels
   - New `ChannelParser` detects `Channel<T>` parameters in commands
   - Generates TypeScript channel listener boilerplate with proper typing
@@ -172,6 +198,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Auto-stages formatted files for commit
 
 ### Changed
+
 - **BREAKING**: Default validation library changed from `"zod"` to `"none"`
   - Running `generate` without `--validation` flag now generates vanilla TypeScript
   - Explicit `--validation zod` required for Zod schema generation
@@ -190,6 +217,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Cleaner, more honest API that accurately reflects function dependencies
 
 ### Removed
+
 - **JavaScript/TypeScript Build Setup**: Removed all Node.js-based build infrastructure
   - Removed `package.json`, `rollup.config.js`, `tsconfig.json`
   - Removed `guest-js/` directory (was for plugin guest code)
@@ -200,6 +228,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Cleaner project structure focused on the core library
 
 ### Fixed
+
 - Fixed vanilla TypeScript generator not using camelCase for function names
   - Command functions now properly convert from snake_case to camelCase (e.g., `get_user_count` → `getUserCount()`)
 
@@ -219,6 +248,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.1] - 2025-11-02
 
 ### Fixed
+
 - **CRITICAL**: Fixed CLI arguments being ignored when configuration file exists
   - CLI arguments (`--validation`, `--project-path`, `--output-path`) now properly override config file settings
   - Previously, when a config file was present, CLI flags were replaced by their default values, causing user-specified options to be ignored
@@ -227,12 +257,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fixes issue where running without `--validation` flag would ignore config file's validation library setting
 
 ### Changed
+
 - CLI argument precedence is now: CLI Arguments > Config File > Hardcoded Defaults
 - Improved help text for CLI arguments to clarify default behavior and config file integration
 
 ## [0.2.0] - 2025-11-01
 
 ### Added
+
 - Added optional hook feature for customizing generated TypeScript code
   - Allows users to inject custom code transformations into the generation process
   - Comprehensive test coverage for hook functionality
@@ -240,20 +272,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Generated files now include metadata about when and with which version they were created
 
 ### Changed
+
 - **BREAKING**: Renamed crate from `tauri-plugin-typegen` to `tauri-typegen`
   - Updated all references, imports, and documentation
   - Updated package names in both Cargo.toml and package.json
   - Updated capability permissions and schema references
 
-## [0.1.5] - 2025-10-31 
+## [0.1.5] - 2025-10-31
 
 ### Fixed
+
 - Fixed regression where `Optional` custom types were not exported properly
 - Fixed regression where primitve types were not imported properly
 
 ## [0.1.4] - 2025-10-30
 
 ### Added
+
 - Added support for custom validation error messages in Zod schemas
   - Validator `message` parameters are now extracted from Rust `#[validate(...)]` attributes
   - Error messages are properly escaped and included in Zod schema validations
@@ -261,11 +296,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Example: `#[validate(length(min = 5, max = 50, message = "Must be 5-50 chars"))]` generates `z.string().min(5, { message: "Must be 5-50 chars" })`
 
 ### Fixed
+
 - Fixed vanilla TypeScript interface properties not using camelCase naming convention
   - Interface properties now consistently use camelCase (e.g., `stringMap` instead of `string_map`)
   - Matches the naming convention already used in Zod schemas for consistency
 
 ### Changed
+
 - Updated `z.record()` generation to use explicit two-parameter syntax for better type safety
   - Now generates `z.record(z.string(), z.number())` instead of `z.record(z.number())`
   - More explicit about both key and value types
@@ -273,27 +310,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.3] - 2025-10-20
 
 ### Fixed
+
 - Fixed camelCase naming convention not being consistently applied to generated TypeScript types
 - Fixed configuration file not being properly loaded from `tauri.conf.json`
 - Fixed topological sorting and forward references in type dependency resolution after refactoring
 - Fixed CLI config loading to properly detect and use `tauri.conf.json` from project directory
 
 ### Changed
-- Changed enum generation to use Zod native enums (`z.enum()`) instead of union types 
+
+- Changed enum generation to use Zod native enums (`z.enum()`) instead of union types
+
 ## [0.1.2] - 2025-10-20
 
 ### Fixed
+
 - Fixed invalid `tauri.conf.json` generation when using standalone configuration files
 - Fixed `tauri.conf.json` path resolution to correctly place file in Rust project directory (`{project-path}/tauri.conf.json`)
 - Improved path detection for default configuration file location using proper parent directory checks
 
 ### Changed
+
 - Reduced CLI verbosity with cleaner progress output using animated spinners (indicatif library)
 - Updated `init` command to require existing `tauri.conf.json` and only update the `plugins.typegen` section
 - Configuration file now defaults to `{project-path}/tauri.conf.json` instead of project root
 - Enhanced verbose mode to properly propagate through AST parsing and analysis steps
 
 ### Added
+
 - Added `indicatif` dependency for progress bar animations
 - Added comprehensive tests for CLI configuration conversion
 - Added tests for tauri.conf.json preservation and plugin section management
@@ -301,11 +344,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.1] - 2025-09-06
 
 ### Fixed
+
 - Fixed invalid `tauri.conf.json` generation when using standalone configuration files
 - Fixed `tauri.conf.json` path resolution to correctly place file in project directory
 - Improved path detection for default configuration file location
 
 ### Changed
+
 - Reduced CLI verbosity with cleaner progress output using animated spinners
 - Improved user experience with single-line progress indication during generation
 - Removed unnecessary info emojis from logging output
@@ -315,6 +360,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0] - 2025-09-05
 
 ### Added
+
 - Initial release of tauri-typegen
 - TypeScript bindings generation for Tauri commands
 - Support for Zod validation library integration
@@ -336,6 +382,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Automatic generation of barrel exports (`index.ts`)
 
 ### Features
+
 - **Zod Generation Mode**: Generates schemas, inferred types, commands, and exports
 - **Vanilla TypeScript Mode**: Generates types, commands, and exports without validation
 - **Verbose Mode**: Detailed logging for debugging and understanding the generation process
@@ -345,9 +392,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Clean separation between AST parsing and code generation
 
 ### Developer Experience
+
 - Progress reporting with step-by-step feedback
 - Helpful error messages with actionable guidance
 - Usage examples printed after successful generation
 - Dependency visualization tools for understanding type relationships
 - Extensive test coverage
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [0.5.3] - 2026-08-24
-
-### Fixed
-
-- **Aliased Tauri Command Parameters**: Type aliases to Tauri-injected types (e.g. `type AppSaveState<'a> = State<'a, Arc<T>>`) are now resolved and skipped when generating command Params, matching the behavior of a direct `State<...>` / `AppHandle` / etc. parameter
-  - Nested aliases are followed with cycle detection
-  - Analysis indexes type aliases before command extraction so same-file and cross-file aliases work
 
 ## [0.5.2] - 2026-06-21
 
 ### Fixed
-
 - **Duplicate Commands Under `#[cfg(...)]` Gates**: Commands declared more than once behind mutually-exclusive `#[cfg(...)]` attributes (the standard cross-platform Tauri pattern) now generate a single TypeScript declaration instead of duplicates (TS2323/TS2393/TS2451)
   - Commands are deduplicated by name at the generation layer (first occurrence in source order wins), consistent with existing event deduplication
   - The analyzer continues to report every declaration; deduplication happens only when building generation contexts
@@ -24,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.1] - 2026-05-28
 
 ### Fixed
-
 - **Deterministic Generation**: Eliminated nondeterministic output across runs
   - Generator inputs are now sorted before rendering for stable ordering
   - Stabilized cache hashing and regeneration invalidation
@@ -32,16 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Normalized generated output formatting
 
 ### Added
-
 - **Snake_case Config Keys**: Support `snake_case` keys in `tauri.conf.json` (e.g. `project_path`)
 - **`src-tauri` as Root**: Support projects where `src-tauri` is the root directory
 
 ### Changed
-
 - **Unified Type Discovery**: Consolidated type discovery logic and removed duplicate traversal in the generators
 
 ### Fixed
-
 - **Rust Type Parsing**: Correctly parse previously unsupported types
   - Module-qualified types (e.g. `std::collections::HashMap`)
   - Slices (e.g. `[u8]`)
@@ -54,7 +42,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.0] - 2026-02-24
 
 ### Added
-
 - **Complex Enum Variant Support**: Full support for Rust enums with tuple and struct variants
   - Simple enums (unit variants only) continue to generate TypeScript string literal unions / `z.enum()`
   - Complex enums (tuple or struct variants) now generate TypeScript discriminated unions / `z.discriminatedUnion()`
@@ -62,7 +49,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Enum variants are included in the AST cache for efficient subsequent runs
 
 ### Changed
-
 - **Serde Attribute Parsing**: Replaced regex-based parsing with `syn` AST functions
   - More robust and accurate handling of `#[serde(...)]` attributes
   - Eliminates edge cases caused by pattern matching on raw token strings
@@ -70,13 +56,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.2] - 2026-02-15
 
 ### Fixed
-
 - **EventParser**: Fixed bug where types were not discovered when moving emitter to external function
 
 ## [0.4.1] - 2026-02-05
 
 ### Added
-
 - **Smart Caching**: Skip regeneration when source files haven't changed
   - Creates `.typecache` file in output directory with hashes of discovered commands, types, and configuration
   - Compares hashes on subsequent runs to determine if regeneration is needed
@@ -90,7 +74,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.0] - 2025-12-26
 
 ### Added
-
 - **Custom Type Mappings**: Added support for mapping external Rust types to TypeScript types via configuration
   - Configure in `tauri.conf.json` under `plugins.typegen.typeMappings`
   - Useful for external crate types like `DateTime<Utc>` → `string` or `PathBuf` → `string`
@@ -113,48 +96,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Ensures generated TypeScript/Zod code has no compilation errors
 
 ### Fixed
-
-- Updated outdated setup instructions
+- Updated outdated setup instructions 
 
 ### Changed
-
 - **BREAKING - TypeScript Type Mappings**: Changed HashMap/BTreeMap generation from `Map<K,V>` to `Record<K,V>`
   - `HashMap<String, number>` now generates `Record<string, number>` instead of `Map<string, number>`
   - More idiomatic TypeScript that matches JSON serialization behavior
 
 ## [0.3.4] - 2025-12-09
-
 ### Fixed
-
 - **Zod**: Fixed bug where `z.coerce.number()` was used for record/map declaration
 
 ## [0.3.3] - 2025-12-04
 
 ### Added
-
 - Generated files now contain a timestamp and tauri-typegen version info
 - Added `--version` flag as CLI argument
 
-### Changed
 
+### Changed
 - Generated zod code now includes type coercion for numbers
 
 ## [0.3.2] - 2025-11-23
 
 ### Fixed
-
 - **Nested Collection Type Discovery**: Fixed bug where nested collection types (e.g., `Vec<HashMap<String, Vec<T>>>`) were not properly discovered when the type was not referenced standalone
   - Type analyzer now recursively traverses nested generic types to discover all referenced custom types
   - Ensures all nested types are included in the generated TypeScript bindings
 
 ### Changed
-
 - Cleaned up unused permissions directory from project structure
 
 ## [0.3.1] - 2025-11-19
 
 ### Fixed
-
 - **Zod Command Generation with Channels**: Fixed bug where commands with both regular parameters and channels generated invalid TypeScript code
   - Previously referenced non-existent `extractChannels` function
   - Now generates explicit channel parameter references (e.g., `{ ...result.data, onProgress: params.onProgress }`)
@@ -162,7 +137,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.0] - 2025-11-13
 
 ### Added
-
 - **Tauri Channel Support**: Automatically generate TypeScript bindings for Tauri IPC Channels
   - New `ChannelParser` detects `Channel<T>` parameters in commands
   - Generates TypeScript channel listener boilerplate with proper typing
@@ -198,7 +172,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Auto-stages formatted files for commit
 
 ### Changed
-
 - **BREAKING**: Default validation library changed from `"zod"` to `"none"`
   - Running `generate` without `--validation` flag now generates vanilla TypeScript
   - Explicit `--validation zod` required for Zod schema generation
@@ -217,7 +190,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Cleaner, more honest API that accurately reflects function dependencies
 
 ### Removed
-
 - **JavaScript/TypeScript Build Setup**: Removed all Node.js-based build infrastructure
   - Removed `package.json`, `rollup.config.js`, `tsconfig.json`
   - Removed `guest-js/` directory (was for plugin guest code)
@@ -228,7 +200,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Cleaner project structure focused on the core library
 
 ### Fixed
-
 - Fixed vanilla TypeScript generator not using camelCase for function names
   - Command functions now properly convert from snake_case to camelCase (e.g., `get_user_count` → `getUserCount()`)
 
@@ -248,7 +219,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.1] - 2025-11-02
 
 ### Fixed
-
 - **CRITICAL**: Fixed CLI arguments being ignored when configuration file exists
   - CLI arguments (`--validation`, `--project-path`, `--output-path`) now properly override config file settings
   - Previously, when a config file was present, CLI flags were replaced by their default values, causing user-specified options to be ignored
@@ -257,14 +227,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fixes issue where running without `--validation` flag would ignore config file's validation library setting
 
 ### Changed
-
 - CLI argument precedence is now: CLI Arguments > Config File > Hardcoded Defaults
 - Improved help text for CLI arguments to clarify default behavior and config file integration
 
 ## [0.2.0] - 2025-11-01
 
 ### Added
-
 - Added optional hook feature for customizing generated TypeScript code
   - Allows users to inject custom code transformations into the generation process
   - Comprehensive test coverage for hook functionality
@@ -272,23 +240,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Generated files now include metadata about when and with which version they were created
 
 ### Changed
-
 - **BREAKING**: Renamed crate from `tauri-plugin-typegen` to `tauri-typegen`
   - Updated all references, imports, and documentation
   - Updated package names in both Cargo.toml and package.json
   - Updated capability permissions and schema references
 
-## [0.1.5] - 2025-10-31
+## [0.1.5] - 2025-10-31 
 
 ### Fixed
-
 - Fixed regression where `Optional` custom types were not exported properly
 - Fixed regression where primitve types were not imported properly
 
 ## [0.1.4] - 2025-10-30
 
 ### Added
-
 - Added support for custom validation error messages in Zod schemas
   - Validator `message` parameters are now extracted from Rust `#[validate(...)]` attributes
   - Error messages are properly escaped and included in Zod schema validations
@@ -296,13 +261,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Example: `#[validate(length(min = 5, max = 50, message = "Must be 5-50 chars"))]` generates `z.string().min(5, { message: "Must be 5-50 chars" })`
 
 ### Fixed
-
 - Fixed vanilla TypeScript interface properties not using camelCase naming convention
   - Interface properties now consistently use camelCase (e.g., `stringMap` instead of `string_map`)
   - Matches the naming convention already used in Zod schemas for consistency
 
 ### Changed
-
 - Updated `z.record()` generation to use explicit two-parameter syntax for better type safety
   - Now generates `z.record(z.string(), z.number())` instead of `z.record(z.number())`
   - More explicit about both key and value types
@@ -310,33 +273,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.3] - 2025-10-20
 
 ### Fixed
-
 - Fixed camelCase naming convention not being consistently applied to generated TypeScript types
 - Fixed configuration file not being properly loaded from `tauri.conf.json`
 - Fixed topological sorting and forward references in type dependency resolution after refactoring
 - Fixed CLI config loading to properly detect and use `tauri.conf.json` from project directory
 
 ### Changed
-
-- Changed enum generation to use Zod native enums (`z.enum()`) instead of union types
-
+- Changed enum generation to use Zod native enums (`z.enum()`) instead of union types 
 ## [0.1.2] - 2025-10-20
 
 ### Fixed
-
 - Fixed invalid `tauri.conf.json` generation when using standalone configuration files
 - Fixed `tauri.conf.json` path resolution to correctly place file in Rust project directory (`{project-path}/tauri.conf.json`)
 - Improved path detection for default configuration file location using proper parent directory checks
 
 ### Changed
-
 - Reduced CLI verbosity with cleaner progress output using animated spinners (indicatif library)
 - Updated `init` command to require existing `tauri.conf.json` and only update the `plugins.typegen` section
 - Configuration file now defaults to `{project-path}/tauri.conf.json` instead of project root
 - Enhanced verbose mode to properly propagate through AST parsing and analysis steps
 
 ### Added
-
 - Added `indicatif` dependency for progress bar animations
 - Added comprehensive tests for CLI configuration conversion
 - Added tests for tauri.conf.json preservation and plugin section management
@@ -344,13 +301,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.1] - 2025-09-06
 
 ### Fixed
-
 - Fixed invalid `tauri.conf.json` generation when using standalone configuration files
 - Fixed `tauri.conf.json` path resolution to correctly place file in project directory
 - Improved path detection for default configuration file location
 
 ### Changed
-
 - Reduced CLI verbosity with cleaner progress output using animated spinners
 - Improved user experience with single-line progress indication during generation
 - Removed unnecessary info emojis from logging output
@@ -360,7 +315,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0] - 2025-09-05
 
 ### Added
-
 - Initial release of tauri-typegen
 - TypeScript bindings generation for Tauri commands
 - Support for Zod validation library integration
@@ -382,7 +336,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Automatic generation of barrel exports (`index.ts`)
 
 ### Features
-
 - **Zod Generation Mode**: Generates schemas, inferred types, commands, and exports
 - **Vanilla TypeScript Mode**: Generates types, commands, and exports without validation
 - **Verbose Mode**: Detailed logging for debugging and understanding the generation process
@@ -392,7 +345,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Clean separation between AST parsing and code generation
 
 ### Developer Experience
-
 - Progress reporting with step-by-step feedback
 - Helpful error messages with actionable guidance
 - Usage examples printed after successful generation

--- a/src/analysis/command_parser.rs
+++ b/src/analysis/command_parser.rs
@@ -1,6 +1,7 @@
 use crate::analysis::serde_parser::SerdeParser;
 use crate::analysis::type_resolver::TypeResolver;
 use crate::models::{CommandInfo, ParameterInfo};
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use syn::{File as SynFile, FnArg, ItemFn, PatType, ReturnType, Type};
 
@@ -23,9 +24,16 @@ impl CommandParser {
         ast: &SynFile,
         file_path: &Path,
         type_resolver: &mut TypeResolver,
+        type_aliases: &HashMap<String, Type>,
     ) -> Result<Vec<CommandInfo>, Box<dyn std::error::Error>> {
         let mut commands = Vec::new();
-        self.extract_commands_from_items(&ast.items, file_path, type_resolver, &mut commands);
+        self.extract_commands_from_items(
+            &ast.items,
+            file_path,
+            type_resolver,
+            type_aliases,
+            &mut commands,
+        );
         Ok(commands)
     }
 
@@ -35,6 +43,7 @@ impl CommandParser {
         items: &[syn::Item],
         file_path: &Path,
         type_resolver: &mut TypeResolver,
+        type_aliases: &HashMap<String, Type>,
         commands: &mut Vec<CommandInfo>,
     ) {
         for item in items {
@@ -42,7 +51,7 @@ impl CommandParser {
                 syn::Item::Fn(func) => {
                     if self.is_tauri_command(func) {
                         if let Some(info) =
-                            self.extract_command_info(func, file_path, type_resolver)
+                            self.extract_command_info(func, file_path, type_resolver, type_aliases)
                         {
                             commands.push(info);
                         }
@@ -50,7 +59,13 @@ impl CommandParser {
                 }
                 syn::Item::Mod(item_mod) => {
                     if let Some((_, items)) = &item_mod.content {
-                        self.extract_commands_from_items(items, file_path, type_resolver, commands);
+                        self.extract_commands_from_items(
+                            items,
+                            file_path,
+                            type_resolver,
+                            type_aliases,
+                            commands,
+                        );
                     }
                 }
                 _ => {}
@@ -74,10 +89,11 @@ impl CommandParser {
         func: &ItemFn,
         file_path: &Path,
         type_resolver: &mut TypeResolver,
+        type_aliases: &HashMap<String, Type>,
     ) -> Option<CommandInfo> {
         let name = func.sig.ident.to_string();
 
-        let parameters = self.extract_parameters(&func.sig.inputs, type_resolver);
+        let parameters = self.extract_parameters(&func.sig.inputs, type_resolver, type_aliases);
         let return_type = self.extract_return_type(&func.sig.output);
         let return_type_structure = type_resolver.parse_type_structure(&return_type);
         let is_async = func.sig.asyncness.is_some();
@@ -109,6 +125,7 @@ impl CommandParser {
         &self,
         inputs: &syn::punctuated::Punctuated<FnArg, syn::token::Comma>,
         type_resolver: &mut TypeResolver,
+        type_aliases: &HashMap<String, Type>,
     ) -> Vec<ParameterInfo> {
         inputs
             .iter()
@@ -117,8 +134,8 @@ impl CommandParser {
                     if let syn::Pat::Ident(pat_ident) = pat.as_ref() {
                         let name = pat_ident.ident.to_string();
 
-                        // Skip Tauri-specific parameters
-                        if self.is_tauri_parameter_type(ty) {
+                        // Skip Tauri-specific parameters (including type aliases to them)
+                        if self.is_tauri_parameter_type(ty, type_aliases) {
                             return None;
                         }
 
@@ -144,8 +161,48 @@ impl CommandParser {
     }
 
     /// Check if a parameter type is a Tauri-specific type that should be skipped
+    /// Respects type aliases that have already been defined
     /// This checks the actual syn::Type to properly handle both imported and fully-qualified types
-    fn is_tauri_parameter_type(&self, ty: &Type) -> bool {
+    fn is_tauri_parameter_type(&self, ty: &Type, type_aliases: &HashMap<String, Type>) -> bool {
+        self.is_tauri_parameter_type_inner(ty, type_aliases, &mut HashSet::new())
+    }
+
+    fn is_tauri_parameter_type_inner(
+        &self,
+        ty: &Type,
+        type_aliases: &HashMap<String, Type>,
+        visiting: &mut HashSet<String>,
+    ) -> bool {
+        // Peel references so `&State<T>` / `&AppHandle` are treated like their targets
+        let ty = match ty {
+            Type::Reference(type_ref) => type_ref.elem.as_ref(),
+            other => other,
+        };
+
+        if self.is_direct_tauri_parameter_type(ty) {
+            return true;
+        }
+
+        // Follow type aliases: `type AppSaveState<'a> = State<'a, T>`
+        if let Type::Path(type_path) = ty {
+            if let Some(last_segment) = type_path.path.segments.last() {
+                let alias_name = last_segment.ident.to_string();
+                if !visiting.insert(alias_name.clone()) {
+                    // Cycle detected
+                    return false;
+                }
+                if let Some(rhs) = type_aliases.get(&alias_name) {
+                    return self.is_tauri_parameter_type_inner(rhs, type_aliases, visiting);
+                }
+            }
+        }
+
+        false
+    }
+
+    /// Check if a parameter type is a Tauri-specific type (no alias resolution).
+    /// This checks the actual syn::Type to properly handle both imported and fully-qualified types.
+    fn is_direct_tauri_parameter_type(&self, ty: &Type) -> bool {
         if let Type::Path(type_path) = ty {
             let segments = &type_path.path.segments;
 
@@ -447,81 +504,85 @@ mod tests {
     mod is_tauri_parameter_type {
         use super::*;
 
+        fn empty_aliases() -> HashMap<String, Type> {
+            HashMap::new()
+        }
+
         #[test]
         fn test_recognizes_app_handle() {
             let parser = CommandParser::new();
             let ty: Type = parse_quote!(tauri::AppHandle);
-            assert!(parser.is_tauri_parameter_type(&ty));
+            assert!(parser.is_tauri_parameter_type(&ty, &empty_aliases()));
         }
 
         #[test]
         fn test_recognizes_imported_app_handle() {
             let parser = CommandParser::new();
             let ty: Type = parse_quote!(AppHandle);
-            assert!(parser.is_tauri_parameter_type(&ty));
+            assert!(parser.is_tauri_parameter_type(&ty, &empty_aliases()));
         }
 
         #[test]
         fn test_recognizes_window_with_generics() {
             let parser = CommandParser::new();
             let ty: Type = parse_quote!(Window<R>);
-            assert!(parser.is_tauri_parameter_type(&ty));
+            assert!(parser.is_tauri_parameter_type(&ty, &empty_aliases()));
         }
 
         #[test]
         fn test_recognizes_state_with_generics() {
             let parser = CommandParser::new();
             let ty: Type = parse_quote!(State<AppState>);
-            assert!(parser.is_tauri_parameter_type(&ty));
+            assert!(parser.is_tauri_parameter_type(&ty, &empty_aliases()));
         }
 
         #[test]
         fn test_recognizes_webview_window() {
             let parser = CommandParser::new();
             let ty: Type = parse_quote!(tauri::WebviewWindow);
-            assert!(parser.is_tauri_parameter_type(&ty));
+            assert!(parser.is_tauri_parameter_type(&ty, &empty_aliases()));
         }
 
         #[test]
         fn test_recognizes_imported_webview_window() {
             let parser = CommandParser::new();
             let ty: Type = parse_quote!(WebviewWindow);
-            assert!(parser.is_tauri_parameter_type(&ty));
+            assert!(parser.is_tauri_parameter_type(&ty, &empty_aliases()));
         }
 
         #[test]
         fn test_recognizes_ipc_request() {
             let parser = CommandParser::new();
             let ty: Type = parse_quote!(tauri::ipc::Request);
-            assert!(parser.is_tauri_parameter_type(&ty));
+            assert!(parser.is_tauri_parameter_type(&ty, &empty_aliases()));
         }
 
         #[test]
         fn test_recognizes_ipc_channel() {
             let parser = CommandParser::new();
             let ty: Type = parse_quote!(tauri::ipc::Channel<String>);
-            assert!(parser.is_tauri_parameter_type(&ty));
+            assert!(parser.is_tauri_parameter_type(&ty, &empty_aliases()));
         }
 
         #[test]
         fn test_recognizes_channel_with_generics() {
             let parser = CommandParser::new();
             let ty: Type = parse_quote!(Channel<ProgressUpdate>);
-            assert!(parser.is_tauri_parameter_type(&ty));
+            assert!(parser.is_tauri_parameter_type(&ty, &empty_aliases()));
         }
 
         #[test]
         fn test_rejects_user_string_type() {
             let parser = CommandParser::new();
             let ty: Type = parse_quote!(String);
-            assert!(!parser.is_tauri_parameter_type(&ty));
+            assert!(!parser.is_tauri_parameter_type(&ty, &empty_aliases()));
         }
 
         #[test]
         fn test_rejects_user_custom_type() {
             let parser = CommandParser::new();
             let ty: Type = parse_quote!(User);
-            assert!(!parser.is_tauri_parameter_type(&ty));
+            assert!(!parser.is_tauri_parameter_type(&ty, &empty_aliases()));
         }
 
         #[test]
@@ -529,7 +590,7 @@ mod tests {
             let parser = CommandParser::new();
             // User might have their own State type without generics
             let ty: Type = parse_quote!(State);
-            assert!(!parser.is_tauri_parameter_type(&ty));
+            assert!(!parser.is_tauri_parameter_type(&ty, &empty_aliases()));
         }
 
         #[test]
@@ -537,7 +598,67 @@ mod tests {
             let parser = CommandParser::new();
             // User might have their own Window type without generics
             let ty: Type = parse_quote!(Window);
-            assert!(!parser.is_tauri_parameter_type(&ty));
+            assert!(!parser.is_tauri_parameter_type(&ty, &empty_aliases()));
+        }
+
+        #[test]
+        fn test_recognizes_alias_to_state() {
+            let parser = CommandParser::new();
+            let mut aliases = HashMap::new();
+            aliases.insert(
+                "AppSaveState".to_string(),
+                parse_quote!(State<'a, Arc<AppSaveService>>),
+            );
+            let ty: Type = parse_quote!(AppSaveState);
+            assert!(parser.is_tauri_parameter_type(&ty, &aliases));
+        }
+
+        #[test]
+        fn test_recognizes_alias_to_tauri_state() {
+            let parser = CommandParser::new();
+            let mut aliases = HashMap::new();
+            aliases.insert(
+                "AppSaveState".to_string(),
+                parse_quote!(tauri::State<'a, Arc<AppSaveService>>),
+            );
+            let ty: Type = parse_quote!(AppSaveState<'_>);
+            assert!(parser.is_tauri_parameter_type(&ty, &aliases));
+        }
+
+        #[test]
+        fn test_recognizes_nested_alias_to_state() {
+            let parser = CommandParser::new();
+            let mut aliases = HashMap::new();
+            aliases.insert("Inner".to_string(), parse_quote!(State<'a, AppState>));
+            aliases.insert("Outer".to_string(), parse_quote!(Inner));
+            let ty: Type = parse_quote!(Outer);
+            assert!(parser.is_tauri_parameter_type(&ty, &aliases));
+        }
+
+        #[test]
+        fn test_cyclic_alias_does_not_hang() {
+            let parser = CommandParser::new();
+            let mut aliases = HashMap::new();
+            aliases.insert("A".to_string(), parse_quote!(B));
+            aliases.insert("B".to_string(), parse_quote!(A));
+            let ty: Type = parse_quote!(A);
+            assert!(!parser.is_tauri_parameter_type(&ty, &aliases));
+        }
+
+        #[test]
+        fn test_rejects_unrelated_alias() {
+            let parser = CommandParser::new();
+            let mut aliases = HashMap::new();
+            aliases.insert("Id".to_string(), parse_quote!(String));
+            let ty: Type = parse_quote!(Id);
+            assert!(!parser.is_tauri_parameter_type(&ty, &aliases));
+        }
+
+        #[test]
+        fn test_recognizes_reference_to_app_handle() {
+            let parser = CommandParser::new();
+            let ty: Type = parse_quote!(&AppHandle);
+            assert!(parser.is_tauri_parameter_type(&ty, &empty_aliases()));
         }
     }
 
@@ -578,13 +699,17 @@ mod tests {
     mod extract_parameters {
         use super::*;
 
+        fn empty_aliases() -> HashMap<String, Type> {
+            HashMap::new()
+        }
+
         #[test]
         fn test_extract_simple_parameter() {
             let parser = CommandParser::new();
             let mut type_resolver = TypeResolver::new();
             let inputs = parse_quote!(name: String);
 
-            let params = parser.extract_parameters(&inputs, &mut type_resolver);
+            let params = parser.extract_parameters(&inputs, &mut type_resolver, &empty_aliases());
 
             assert_eq!(params.len(), 1);
             assert_eq!(params[0].name, "name");
@@ -598,7 +723,7 @@ mod tests {
             let mut type_resolver = TypeResolver::new();
             let inputs = parse_quote!(email: Option<String>);
 
-            let params = parser.extract_parameters(&inputs, &mut type_resolver);
+            let params = parser.extract_parameters(&inputs, &mut type_resolver, &empty_aliases());
 
             assert_eq!(params.len(), 1);
             assert_eq!(params[0].name, "email");
@@ -611,7 +736,7 @@ mod tests {
             let mut type_resolver = TypeResolver::new();
             let inputs = parse_quote!(name: String, age: i32);
 
-            let params = parser.extract_parameters(&inputs, &mut type_resolver);
+            let params = parser.extract_parameters(&inputs, &mut type_resolver, &empty_aliases());
 
             assert_eq!(params.len(), 2);
             assert_eq!(params[0].name, "name");
@@ -624,7 +749,7 @@ mod tests {
             let mut type_resolver = TypeResolver::new();
             let inputs = parse_quote!(app: AppHandle, name: String);
 
-            let params = parser.extract_parameters(&inputs, &mut type_resolver);
+            let params = parser.extract_parameters(&inputs, &mut type_resolver, &empty_aliases());
 
             // AppHandle should be filtered out
             assert_eq!(params.len(), 1);
@@ -637,7 +762,7 @@ mod tests {
             let mut type_resolver = TypeResolver::new();
             let inputs = parse_quote!(state: State<AppState>, name: String);
 
-            let params = parser.extract_parameters(&inputs, &mut type_resolver);
+            let params = parser.extract_parameters(&inputs, &mut type_resolver, &empty_aliases());
 
             // State should be filtered out
             assert_eq!(params.len(), 1);
@@ -650,11 +775,33 @@ mod tests {
             let mut type_resolver = TypeResolver::new();
             let inputs = parse_quote!(progress: Channel<u32>, name: String);
 
-            let params = parser.extract_parameters(&inputs, &mut type_resolver);
+            let params = parser.extract_parameters(&inputs, &mut type_resolver, &empty_aliases());
 
             // Channel should be filtered out
             assert_eq!(params.len(), 1);
             assert_eq!(params[0].name, "name");
+        }
+
+        #[test]
+        fn test_filters_aliased_state() {
+            let parser = CommandParser::new();
+            let mut type_resolver = TypeResolver::new();
+            let mut aliases = HashMap::new();
+            aliases.insert(
+                "AppSaveState".to_string(),
+                parse_quote!(State<'a, Arc<AppSaveService>>),
+            );
+            let inputs = parse_quote!(
+                state: AppSaveState,
+                source_path: String,
+                relative_dest_path: String
+            );
+
+            let params = parser.extract_parameters(&inputs, &mut type_resolver, &aliases);
+
+            assert_eq!(params.len(), 2);
+            assert_eq!(params[0].name, "source_path");
+            assert_eq!(params[1].name, "relative_dest_path");
         }
 
         #[test]
@@ -663,7 +810,7 @@ mod tests {
             let mut type_resolver = TypeResolver::new();
             let inputs = parse_quote!();
 
-            let params = parser.extract_parameters(&inputs, &mut type_resolver);
+            let params = parser.extract_parameters(&inputs, &mut type_resolver, &empty_aliases());
 
             assert_eq!(params.len(), 0);
         }
@@ -673,6 +820,10 @@ mod tests {
     mod extract_command_info {
         use super::*;
         use std::path::PathBuf;
+
+        fn empty_aliases() -> HashMap<String, Type> {
+            HashMap::new()
+        }
 
         #[test]
         fn test_extract_simple_command() {
@@ -686,7 +837,8 @@ mod tests {
             };
             let path = PathBuf::from("test.rs");
 
-            let info = parser.extract_command_info(&func, &path, &mut type_resolver);
+            let info =
+                parser.extract_command_info(&func, &path, &mut type_resolver, &empty_aliases());
 
             assert!(info.is_some());
             let info = info.unwrap();
@@ -708,7 +860,8 @@ mod tests {
             };
             let path = PathBuf::from("test.rs");
 
-            let info = parser.extract_command_info(&func, &path, &mut type_resolver);
+            let info =
+                parser.extract_command_info(&func, &path, &mut type_resolver, &empty_aliases());
 
             assert!(info.is_some());
             let info = info.unwrap();
@@ -728,7 +881,8 @@ mod tests {
             };
             let path = PathBuf::from("test.rs");
 
-            let info = parser.extract_command_info(&func, &path, &mut type_resolver);
+            let info =
+                parser.extract_command_info(&func, &path, &mut type_resolver, &empty_aliases());
 
             assert!(info.is_some());
             let info = info.unwrap();

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -159,9 +159,6 @@ impl CommandAnalyzer {
 
                 commands.extend(file_commands);
                 self.discovered_events.extend(file_events);
-
-                // Build type definition index from this file
-                self.index_type_definitions(&parsed_file.ast, parsed_file.path.as_path());
             }
         }
 

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -40,6 +40,8 @@ pub struct CommandAnalyzer {
     discovered_structs: HashMap<String, StructInfo>,
     /// Discovered event emissions
     discovered_events: Vec<EventInfo>,
+    /// Type aliases (`type Foo = Bar`) keyed by alias name → RHS type
+    type_aliases: HashMap<String, syn::Type>,
 }
 
 impl CommandAnalyzer {
@@ -54,6 +56,7 @@ impl CommandAnalyzer {
             dependency_graph: TypeDependencyGraph::new(),
             discovered_structs: HashMap::new(),
             discovered_events: Vec::new(),
+            type_aliases: HashMap::new(),
         }
     }
 
@@ -86,6 +89,16 @@ impl CommandAnalyzer {
         // Extract commands from cached ASTs
         let mut file_paths: Vec<PathBuf> = self.ast_cache.keys().cloned().collect();
         file_paths.sort_unstable();
+
+        // Pass 1: Index type definitions (structs, enums, aliases) before command extraction
+        // so aliased Tauri types (e.g. type AppSaveState = State<...>) can be skipped.
+        for file_path in &file_paths {
+            if let Some(parsed_file) = self.ast_cache.get_cloned(file_path) {
+                self.index_type_definitions(&parsed_file.ast, parsed_file.path.as_path());
+            }
+        }
+
+        // Pass 2: Extract commands, channels, and events from cached ASTs
         let mut commands = Vec::new();
         let mut type_names_to_discover = HashSet::new();
 
@@ -101,6 +114,7 @@ impl CommandAnalyzer {
                     &parsed_file.ast,
                     parsed_file.path.as_path(),
                     &mut self.type_resolver,
+                    &self.type_aliases,
                 )?;
 
                 // Extract channels for each command
@@ -198,6 +212,9 @@ impl CommandAnalyzer {
             Ok(_) => {
                 // Extract commands and events from the cached AST
                 if let Some(parsed_file) = self.ast_cache.get_cloned(&path_buf) {
+                    // Index type definitions (including aliases) before command extraction
+                    self.index_type_definitions(&parsed_file.ast, path_buf.as_path());
+
                     // Extract events
                     let file_events = self.event_parser.extract_events_from_ast(
                         &parsed_file.ast,
@@ -211,6 +228,7 @@ impl CommandAnalyzer {
                         &parsed_file.ast,
                         path_buf.as_path(),
                         &mut self.type_resolver,
+                        &self.type_aliases,
                     )?;
 
                     // Extract channels for each command
@@ -263,6 +281,12 @@ impl CommandAnalyzer {
                         self.dependency_graph
                             .add_type_definition(enum_name, file_path.to_path_buf());
                     }
+                }
+                syn::Item::Type(item_type) => {
+                    let alias_name = item_type.ident.to_string();
+                    self.type_aliases
+                        .entry(alias_name)
+                        .or_insert_with(|| (*item_type.ty).clone());
                 }
                 syn::Item::Mod(item_mod) => {
                     if let Some((_, items)) = &item_mod.content {

--- a/tests/integration_e2e.rs
+++ b/tests/integration_e2e.rs
@@ -859,3 +859,89 @@ fn test_cfg_gated_duplicate_command_emitted_once() {
         types_ts
     );
 }
+
+/// Type aliases to Tauri injectables (e.g. `type AppSaveState = State<...>`) must be
+/// skipped from generated Params, just like a direct `State<...>` parameter.
+#[test]
+fn test_aliased_state_parameter_omitted_from_params() {
+    let project = TestProject::new();
+
+    project.write_file(
+        "main.rs",
+        r#"
+        use std::sync::Arc;
+        use tauri::State;
+
+        pub struct AppSaveService;
+
+        impl AppSaveService {
+            pub fn copy_file(&self, _source: &str, _dest: &str) -> Result<(), String> {
+                Ok(())
+            }
+        }
+
+        type AppSaveState<'a> = State<'a, Arc<AppSaveService>>;
+
+        #[tauri::command]
+        pub fn copy_file(
+            state: AppSaveState,
+            source_path: String,
+            relative_dest_path: String,
+        ) -> Result<(), String> {
+            state
+                .copy_file(&source_path, &relative_dest_path)
+                .map_err(|e| e.to_string())
+        }
+    "#,
+    );
+
+    let (analyzer, commands) = project.analyze();
+
+    assert_eq!(commands.len(), 1);
+    assert_eq!(commands[0].name, "copy_file");
+    assert_eq!(commands[0].parameters.len(), 2);
+    assert!(
+        commands[0]
+            .parameters
+            .iter()
+            .all(|p| p.name != "state" && !p.rust_type.contains("AppSaveState")),
+        "aliased State parameter should be filtered out. Got: {:?}",
+        commands[0]
+            .parameters
+            .iter()
+            .map(|p| (&p.name, &p.rust_type))
+            .collect::<Vec<_>>(),
+    );
+
+    let generator = TestGenerator::new();
+    generator.generate(
+        &commands,
+        analyzer.get_discovered_structs(),
+        &analyzer,
+        None,
+        None,
+    );
+
+    let types = generator.read_file("types.ts");
+
+    assert!(
+        types.contains("export interface CopyFileParams"),
+        "Should emit CopyFileParams. Got:\n{}",
+        types
+    );
+    assert!(
+        types.contains("sourcePath"),
+        "Should include sourcePath. Got:\n{}",
+        types
+    );
+    assert!(
+        types.contains("relativeDestPath"),
+        "Should include relativeDestPath. Got:\n{}",
+        types
+    );
+    assert!(
+        !types.contains("state") && !types.contains("AppSaveState"),
+        "Should not include aliased State as a Params field. Got:\n{}",
+        types
+    );
+}


### PR DESCRIPTION
## Summary
Defining a type alias such as `type AppSaveState<'a> = State<'a, Arc<AppSaveService>>;` and using it in a command, for example:
```rust
#[tauri::command]
pub fn copy_file(
    state: AppSaveState,
    source_path: String,
    relative_dest_path: String,
) -> Result<(), String>
```
causes it to get exported as:
```ts
export interface CopyFileParams {
  state: AppSaveState;
  sourcePath: string;
  relativeDestPath: string;
  [key: string]: unknown;
}
```

## Changes
The analysis indexes type aliases and runs a two-pass flow (index -> extract) so that aliases are available before command filtering. Extended `is_tauri_parameter_type` by checking for aliases. Added Unit + e2e tests to cover the changes.